### PR TITLE
fix: add Bootstrap static resources to webpack bundle

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -27,7 +27,9 @@ module.exports = {
 	plugins: [
 		new CopyPlugin({
 			patterns: [
-				{ from: "src/static" }
+				{ from: "src/static" },
+				{ from: "node_modules/bootstrap/dist/css/bootstrap.min.css", to: "bootstrap/dist/css/bootstrap.min.css"},
+				{ from: "node_modules/bootstrap/dist/js/bootstrap.min.js", to: "bootstrap/dist/js/bootstrap.min.js"}
 			]
 		})
 	]


### PR DESCRIPTION
Fixes https://github.com/Attacktive/ipa-to-pronunciation-respelling/issues/25.