### PR TITLE
fix: accept common symbols that can be often used with IPA

### DIFF
--- a/src/scripts/converter.ts
+++ b/src/scripts/converter.ts
@@ -1,4 +1,4 @@
-import { mappings, validChunks, SECONDARY_STRESS_MARK, STRESS_MARK } from "./mappings";
+import { mappings, validChunks, SECONDARY_STRESS_MARK, STRESS_MARK, acceptedSymbols } from "./mappings";
 
 export function convert(ipa: string) {
 	const tokens = tokenize(ipa);
@@ -21,6 +21,8 @@ export function convert(ipa: string) {
 			converted = mapped[0];
 		} else if (typeof mapped === "string") {
 			converted = mapped;
+		} else if (acceptedSymbols.includes(token)) {
+			converted = token;
 		} else {
 			throw Error(`Token "${token}" has no mapping!`);
 		}

--- a/src/scripts/mappings.ts
+++ b/src/scripts/mappings.ts
@@ -74,10 +74,7 @@ export const SECONDARY_STRESS_MARK = "ˌ";
 export const consonants = [...consonantMappings.keys()];
 export const vowels = [...vowelMappings.keys()];
 
-export const validChunks = [...consonants, ...vowels, STRESS_MARK, SECONDARY_STRESS_MARK];
-
 // miscellaneous
-validChunks.push("/");
-validChunks.push("[");
-validChunks.push("]");
-validChunks.push(" ");
+export const acceptedSymbols = ["/", "[", "]", " "];
+
+export const validChunks = [...consonants, ...vowels, STRESS_MARK, SECONDARY_STRESS_MARK, ...acceptedSymbols];


### PR DESCRIPTION
Fixes https://github.com/Attacktive/ipa-to-pronunciation-respelling/issues/33.