### PR TITLE
feature: ignore long vowel symbol

### DIFF
--- a/src/scripts/converter.test.ts
+++ b/src/scripts/converter.test.ts
@@ -113,5 +113,20 @@ describe(
 			'handles multiple syllables with stress',
 			() => expect(convert('ˈkæt.ə.ˈpɪl.ər')).toBe('KAT uh P(I|IH)L uhr')
 		);
+
+		it(
+			'ignores parentheses and length marks but keeps slashes',
+			() => expect(convert('/həˈloʊ(ː)/')).toBe('/HUHLOH/')
+		);
+
+		it(
+			'ignores parentheses',
+			() => expect(convert('(həˈloʊ)')).toBe('HUHLOH')
+		);
+
+		it(
+			'ignores length marks',
+			() => expect(convert('həˈloːʊ')).toBe('HUHLOH')
+		);
 	}
 );

--- a/src/scripts/converter.ts
+++ b/src/scripts/converter.ts
@@ -1,4 +1,4 @@
-import { mappings, validChunks, SECONDARY_STRESS_MARK, STRESS_MARK, acceptedSymbols, sonorityRanks, syllableSeparatorSymbols } from './mappings';
+import { mappings, validChunks, SECONDARY_STRESS_MARK, STRESS_MARK, acceptedSymbols, sonorityRanks, syllableSeparatorSymbols, ignoredSymbols } from './mappings';
 
 function getSonority(token: string): number {
 	return sonorityRanks.get(token) ?? 0;
@@ -69,7 +69,13 @@ function tokenize(ipa: string) {
 }
 
 export function convert(ipa: string) {
-	const tokens = tokenize(ipa);
+	// Remove ignored symbols before tokenization
+	let cleanedIpa = ipa;
+	for (const ignoredSymbol of ignoredSymbols) {
+		cleanedIpa = cleanedIpa.replaceAll(ignoredSymbol, '');
+	}
+	
+	const tokens = tokenize(cleanedIpa);
 	const syllableBoundaries = findSyllableBoundaries(tokens);
 	const result: string[] = [];
 

--- a/src/scripts/mappings.ts
+++ b/src/scripts/mappings.ts
@@ -123,7 +123,8 @@ const consonants = [...consonantMappings.keys()];
 const vowels = [...vowelMappings.keys()];
 
 const syllableSeparatorSymbols = [' ', '.', 'ˌ'];
-const acceptedSymbols = [...syllableSeparatorSymbols, '/', '[', ']', '(', ')'];
+const acceptedSymbols = [...syllableSeparatorSymbols, '/', '[', ']'];
+const ignoredSymbols = ['(', ')', 'ː'];
 
 const validChunks = [...consonants, ...vowels, STRESS_MARK, SECONDARY_STRESS_MARK, ...acceptedSymbols];
 
@@ -153,4 +154,4 @@ const sonorityRanks = new Map<string, number>([
 	['p', 2], ['b', 2], ['t', 2], ['d', 2], ['ʈ', 2], ['ɖ', 2], ['c', 2], ['ɟ', 2], ['k', 2], ['g', 2], ['q', 2], ['ɢ', 2], ['ʔ', 2]
 ]);
 
-export { mappings, STRESS_MARK, SECONDARY_STRESS_MARK, consonants, vowels, acceptedSymbols, syllableSeparatorSymbols, validChunks, sonorityRanks };
+export { mappings, STRESS_MARK, SECONDARY_STRESS_MARK, consonants, vowels, acceptedSymbols, ignoredSymbols, syllableSeparatorSymbols, validChunks, sonorityRanks };


### PR DESCRIPTION
Plus, made it ignore parentheses too as it's not valid English respelling.

Resolves https://github.com/Attacktive/ipa-to-pronunciation-respelling/issues/328.