### PR TITLE
fix: support tie bar, dark L, plain e, syllabic marker and hyphen

### DIFF
--- a/src/scripts/converter.test.ts
+++ b/src/scripts/converter.test.ts
@@ -138,5 +138,35 @@ describe(
 			'r between vowels syllabifies as onset of next syllable ("berry")',
 			() => expect(convert('ˈbɛri')).toBe('B(E|EH)Ree')
 		);
+
+		it(
+			'handles tie bar affricate ("judge")',
+			() => expect(convert('/d͡ʒʌd͡ʒ/')).toBe('/j(u|uh)j/')
+		);
+
+		it(
+			'handles trailing hyphen ("curious")',
+			() => expect(convert('/ˈkjɔː-/')).toBe('/KYAW/')
+		);
+
+		it(
+			'handles plain e vowel ("clean")',
+			() => expect(convert('/kleːn/')).toBe('/kl(e|eh)n/')
+		);
+
+		it(
+			'handles tie bar affricate with syllabic consonant ("region")',
+			() => expect(convert('/ˈɹiːd͡ʒn̩/')).toBe('/REEJn/')
+		);
+
+		it(
+			'handles dark l ("bowl")',
+			() => expect(convert('/bəʊɫ/')).toBe('/buhuul/')
+		);
+
+		it(
+			'handles tie bar affricate ("choose")',
+			() => expect(convert('/t͡ʃuːz/')).toBe('/(ch|tch)ooz/')
+		);
 	}
 );

--- a/src/scripts/mappings.ts
+++ b/src/scripts/mappings.ts
@@ -11,6 +11,7 @@ consonantMappings.set('dʒ', 'j');
 consonantMappings.set('k', 'k');
 consonantMappings.set('x', 'kh');
 consonantMappings.set('l', 'l');
+consonantMappings.set('ɫ', 'l');
 consonantMappings.set('ʎ', 'ly');
 consonantMappings.set('m', 'm');
 consonantMappings.set('ɱ', 'm');
@@ -63,6 +64,7 @@ vowelMappings.set('ɑr', 'ar');
 vowelMappings.set('ær', 'arr');
 vowelMappings.set('ɔː', 'aw');
 vowelMappings.set('eɪ', 'ay');
+vowelMappings.set('e', ['e', 'eh']);
 vowelMappings.set('ɛ', ['e', 'eh']);
 vowelMappings.set('iː', 'ee');
 vowelMappings.set('i', 'ee');
@@ -126,7 +128,7 @@ const vowels = [...vowelMappings.keys()];
 
 const syllableSeparatorSymbols = [' ', '.'];
 const acceptedSymbols = [...syllableSeparatorSymbols, '/', '[', ']'];
-const ignoredSymbols = ['(', ')', 'ː'];
+const ignoredSymbols = ['(', ')', 'ː', '͡', '̩', '-'];
 
 const validChunks = [...consonants, ...vowels, STRESS_MARK, SECONDARY_STRESS_MARK, ...acceptedSymbols]
 	.sort((a, b) => b.length - a.length);
@@ -149,7 +151,7 @@ const sonorityRanks = new Map<string, number>([
 	['j', 7], ['w', 7], ['ɥ', 7], ['ɰ', 7], ['hw', 7],
 
 	// Liquids (6)
-	['l', 6], ['r', 6], ['ɹ', 6], ['ɾ', 6], ['ɽ', 6], ['ʎ', 6], ['ʟ', 6],
+	['l', 6], ['ɫ', 6], ['r', 6], ['ɹ', 6], ['ɾ', 6], ['ɽ', 6], ['ʎ', 6], ['ʟ', 6],
 
 	// Nasals (5)
 	['m', 5], ['ɱ', 5], ['n', 5], ['ɳ', 5], ['ŋ', 5], ['ɴ', 5],


### PR DESCRIPTION
## Summary

Addresses the failures reported in #576 (issue stays open for continued smoke test tracking).

- `͡` (U+0361 COMBINING DOUBLE INVERTED BREVE, tie bar) added to `ignoredSymbols` — strips the tie bar so `d͡ʒ`/`t͡ʃ` reduce to the already-mapped `dʒ`/`tʃ` digraphs
- `̩` (U+0329 COMBINING VERTICAL LINE BELOW, syllabic marker) added to `ignoredSymbols` — strips it from syllabic consonants like `n̩`
- `-` added to `ignoredSymbols` — handles trailing/midword hyphens used as continuation or compound markers
- `e` (plain ASCII) mapped to `[e, eh]` in `vowelMappings` (same as `ɛ`)
- `ɫ` (U+026B LATIN SMALL LETTER L WITH MIDDLE TILDE, dark/velarized L) mapped to `l` in `consonantMappings` with sonority rank 6 (liquid)

## Test plan

- [x] Regression tests added for all six failing words: `judge`, `curious`, `clean`, `region`, `bowl`, `choose`
- [x] All 34 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)