### PR TITLE
fix: respell juː as ew

### DIFF
--- a/src/scripts/converter.test.ts
+++ b/src/scripts/converter.test.ts
@@ -130,6 +130,11 @@ describe(
 		);
 
 		it(
+			'respells juː as ew after the length mark is stripped ("few")',
+			() => expect(convert('fjuː')).toBe('few')
+		);
+
+		it(
 			'stress mark terminates the prior syllable without an explicit "." ("cater")',
 			() => expect(convert('kæˈtər')).toBe('kaTER')
 		);

--- a/src/scripts/mappings.ts
+++ b/src/scripts/mappings.ts
@@ -71,6 +71,7 @@ vowelMappings.set('i', 'ee');
 vowelMappings.set('ɪər', 'eer');
 vowelMappings.set('ɛr', 'err');
 vowelMappings.set('juː', 'ew');
+vowelMappings.set('ju', 'ew');
 vowelMappings.set('aɪ', ['eye', 'y']);
 vowelMappings.set('ɪ', ['i', 'ih']);
 vowelMappings.set('aɪər', 'ire');
@@ -141,7 +142,7 @@ const sonorityRanks = new Map<string, number>([
 	['ɑː', 8], ['iː', 8], ['uː', 8], ['ɔː', 8], ['juː', 8], ['ɑːr', 8], ['ɜːr', 8], ['ɔːr', 8],
 	// Diphthongs and rhotic vowels
 	['aɪ', 8], ['eɪ', 8], ['ɔɪ', 8], ['aʊ', 8], ['oʊ', 8], ['ɪə', 8], ['ɛə', 8], ['ʊə', 8],
-	['ər', 8], ['ɜr', 8], ['ɑr', 8], ['ɔr', 8],
+	['ər', 8], ['ɜr', 8], ['ɑr', 8], ['ɔr', 8], ['ju', 8],
 	['ɛr', 8], ['ɪr', 8], ['ʊr', 8], ['ʌr', 8], ['ɒr', 8], ['ær', 8],
 	['ɛər', 8], ['ɪər', 8], ['ʊər', 8], ['aɪər', 8], ['ɔɪər', 8], ['aʊər', 8], ['jʊər', 8],
 	// Nasalized vowels


### PR DESCRIPTION
## Summary

Closes #588. The length mark `ː` is stripped before tokenization, so the `juː` → `ew` mapping never matched: the stripped `ju` tokenized as `j` + `u`, respelling `fjuː` as `fyoo` instead of `few`.

Fix mirrors the existing length-mark aliases (`ɜr`, `ɑr`, `ɔr`): a `ju` → `ew` alias plus its `sonorityRanks` entry (the module-load validation added in #576 enforces the pair — nice guard, by the way 👏).

## Test plan

- [x] New test written first and watched fail (`expected 'fyoo' to be 'few'`), then pass
- [x] `bunx vitest run` — 35/35 pass
- [x] `bunx eslint .` / `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
