### PR TITLE
fix: treat secondary stress mark as a syllable break

### DIFF
--- a/src/scripts/converter.test.ts
+++ b/src/scripts/converter.test.ts
@@ -173,5 +173,15 @@ describe(
 			'handles tie bar affricate ("choose")',
 			() => expect(convert('/t͡ʃuːz/')).toBe('/(ch|tch)ooz/')
 		);
+
+		it(
+			'secondary stress mark terminates the prior syllable ("abstract", noun)',
+			() => expect(convert('ˈæbˌstrækt')).toBe('AB(s|ss)trakt')
+		);
+
+		it(
+			'secondary stress mark stops primary stress from bleeding into the next syllable ("A-B")',
+			() => expect(convert('ˈeɪˌbiː')).toBe('AYbee')
+		);
 	}
 );

--- a/src/scripts/converter.ts
+++ b/src/scripts/converter.ts
@@ -98,6 +98,8 @@ export const convert = (ipa: string) => {
 		}
 
 		if (token === SECONDARY_STRESS_MARK) {
+			// A syllable break without uppercasing; the respelling key leaves secondary stress unmarked.
+			flushSyllable();
 			continue;
 		}
 


### PR DESCRIPTION
Fixes #591

## Root cause
The converter loop `continue`d on `SECONDARY_STRESS_MARK` before doing anything with it, so `ˌ` was silently dropped: it never terminated the syllable being accumulated, and a pending primary stress could bleed across it (`convert('ˈeɪˌbiː')` returned `AYBEE`).

Note: the half of the issue about `ˌ` being unreachable in `syllableSeparatorSymbols` is stale — `ˌ` is no longer in that list (it's now `[' ', '.']`), so only the silent drop remained.

## Fix
`ˌ` now flushes the current syllable, giving it real syllable-break semantics. It stays visually unmarked because the [respelling key the project follows](https://en.wikipedia.org/wiki/Help:Pronunciation_respelling_key) capitalizes only primary stress.

Before → after:
- `ˈeɪˌbiː`: `AYBEE` → `AYbee`
- `ˈæbˌstrækt`: `AB(S|SS)Trakt` → `AB(s|ss)trakt`

The remaining imperfection for `ˌæbˈstrækt` (stress covering only part of the following syllable) is the sonority-boundary problem tracked separately in #590 and is out of scope here.

## Testing
- Two new vitest cases covering both behaviors above; written first and watched fail.
- Full suite: 37/37 pass; eslint and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)