### PR TITLE
bugfix: handle IPA diacritics and accents robustly in the converter

### DIFF
--- a/src/scripts/converter.test.ts
+++ b/src/scripts/converter.test.ts
@@ -160,6 +160,16 @@ describe(
 		);
 
 		it(
+			'respells bare o as aw after the length mark is stripped ("quarter")',
+			() => expect(convert('/ˈkoː.tɘ/')).toBe('/KAW tuh/')
+		);
+
+		it(
+			'ignores the non-syllabic diacritic U+032F ("area")',
+			() => expect(convert('/ˈɛə̯ɹɪə̯/')).toBe('/(E|EH)UHR(i|ih)uh/')
+		);
+
+		it(
 			'handles tie bar affricate with syllabic consonant ("region")',
 			() => expect(convert('/ˈɹiːd͡ʒn̩/')).toBe('/REEJn/')
 		);
@@ -182,6 +192,41 @@ describe(
 		it(
 			'secondary stress mark stops primary stress from bleeding into the next syllable ("A-B")',
 			() => expect(convert('ˈeɪˌbiː')).toBe('AYbee')
+		);
+	}
+);
+
+describe(
+	'normalization and diacritic resilience',
+	() => {
+		it(
+			'drops an aspiration modifier letter ("tʰ")',
+			() => expect(convert('tʰ')).toBe('t')
+		);
+
+		it(
+			'decomposes a precomposed accented vowel via NFD ("ẽ")',
+			() => expect(convert('ẽ')).toBe('(e|eh)')
+		);
+
+		it(
+			'drops a half-length modifier ("ɛˑ")',
+			() => expect(convert('ɛˑ')).toBe('(e|eh)')
+		);
+
+		it(
+			'drops an unrecognized combining diacritic ("n̥" voiceless)',
+			() => expect(convert('n̥')).toBe('n')
+		);
+
+		it(
+			'keeps ç mapped after NFD key normalization ("ç")',
+			() => expect(convert('ç')).toBe('ch')
+		);
+
+		it(
+			'keeps nasal vowel chunks intact ("ɑ̃")',
+			() => expect(convert('ɑ̃')).toBe('on')
 		);
 	}
 );

--- a/src/scripts/converter.ts
+++ b/src/scripts/converter.ts
@@ -3,6 +3,9 @@ import { symbolByIpa, validChunks, SECONDARY_STRESS_MARK, STRESS_MARK, acceptedS
 const rColoredVowelChunks = new Set(vowels.filter(v => v.endsWith('r')));
 const vowelChunksByLength = [...vowels].sort((a, b) => b.length - a.length);
 
+// Unrecognized combining marks (\p{M}) and spacing modifiers (\p{Lm}) are dropped, not errored — they're phonetic detail we can't respell.
+const DROPPABLE_DIACRITIC = /[\p{M}\p{Lm}]/u;
+
 const isSonorityValley = (previous: number | undefined, current: number | undefined, next: number | undefined): boolean => current !== undefined
 	&& previous !== undefined
 	&& next !== undefined
@@ -37,36 +40,50 @@ const convertToken = (token: string): string => {
 	throw Error(`Token "${token}" has no mapping!`);
 };
 
+const matchChunkAt = (ipa: string, i: number): string | undefined => {
+	for (const chunk of validChunks) {
+		if (!ipa.startsWith(chunk, i)) {
+			continue;
+		}
+
+		// Skip an r-coloured vowel when another vowel follows, so the r becomes the next syllable's onset.
+		const rest = ipa.substring(i + chunk.length);
+		if (rColoredVowelChunks.has(chunk) && vowelChunksByLength.some(vowel => rest.startsWith(vowel))) {
+			continue;
+		}
+
+		return chunk;
+	}
+
+	return undefined;
+};
+
 const tokenize = (ipa: string) => {
 	const result = [];
 
 	for (let i = 0; i < ipa.length;) {
-		let foundMatch = false;
-		for (const chunk of validChunks) {
-			if (ipa.startsWith(chunk, i)) {
-				const rest = ipa.substring(i + chunk.length);
-				if (rColoredVowelChunks.has(chunk) && vowelChunksByLength.some(vowel => rest.startsWith(vowel))) {
-					continue;
-				}
-
-				result.push(chunk);
-				i += chunk.length;
-				foundMatch = true;
-				break;
-			}
+		const chunk = matchChunkAt(ipa, i);
+		if (chunk !== undefined) {
+			result.push(chunk);
+			i += chunk.length;
+			continue;
 		}
 
-		if (!foundMatch) {
-			throw Error(`${ipa} contains unsupported symbol(s) around: "${ipa.charAt(i)}".`);
+		// An unrecognized diacritic or modifier: drop it and keep the base symbol.
+		if (DROPPABLE_DIACRITIC.test(ipa.charAt(i))) {
+			i++;
+			continue;
 		}
+
+		throw Error(`${ipa} contains unsupported symbol(s) around: "${ipa.charAt(i)}".`);
 	}
 
 	return result;
 };
 
 export const convert = (ipa: string) => {
-	// Remove ignored symbols before tokenization
-	let cleanedIpa = ipa;
+	// NFD so precomposed accents (ĩ, ñ) split into a base we map plus a mark we can drop.
+	let cleanedIpa = ipa.normalize('NFD');
 	for (const ignoredSymbol of ignoredSymbols) {
 		cleanedIpa = cleanedIpa.replaceAll(ignoredSymbol, '');
 	}

--- a/src/scripts/mappings.ts
+++ b/src/scripts/mappings.ts
@@ -152,6 +152,8 @@ const vowelSymbols = [
 	vowel('ɚ', 'er'),
 	vowel('ɝ', 'ur'),
 	vowel('ɔ', 'aw'),
+	vowel('o', 'aw'),
+	vowel('oː', 'aw'),
 	vowel('a', 'ah'),
 	vowel('ɑ̃', 'on'),
 	vowel('ɛ̃', 'an'),
@@ -160,7 +162,7 @@ const vowelSymbols = [
 ];
 
 const symbols = [...consonantSymbols, ...vowelSymbols];
-const symbolByIpa = new Map(symbols.map(symbol => [symbol.ipa, symbol]));
+const symbolByIpa = new Map(symbols.map(symbol => [symbol.ipa.normalize('NFD'), symbol]));
 
 const STRESS_MARK = 'ˈ';
 const SECONDARY_STRESS_MARK = 'ˌ';
@@ -170,9 +172,12 @@ const vowels = vowelSymbols.map(({ ipa }) => ipa);
 
 const syllableSeparatorSymbols = [' ', '.'];
 const acceptedSymbols = [...syllableSeparatorSymbols, '/', '[', ']'];
-const ignoredSymbols = ['(', ')', 'ː', '͡', '̩', '-'];
+
+// Stripped pre-tokenization: parens/hyphen, length mark, and tie bars U+0361/U+035C (the bars must go so dʒ/tʃ become adjacent and match one chunk); other diacritics/modifiers are dropped in the tokenizer.
+const ignoredSymbols = ['(', ')', 'ː', '\u0361', '\u035C', '-'];
 
 const validChunks = [...consonants, ...vowels, STRESS_MARK, SECONDARY_STRESS_MARK, ...acceptedSymbols]
+	.map(chunk => chunk.normalize('NFD'))
 	.sort((a, b) => b.length - a.length);
 
 export { symbolByIpa, STRESS_MARK, SECONDARY_STRESS_MARK, consonants, vowels, acceptedSymbols, ignoredSymbols, syllableSeparatorSymbols, validChunks };


### PR DESCRIPTION
## What

Fixes #576. The IPA converter's smoke test was crashing on real dictionary transcriptions. This turns the reactive whack-a-mole (add each diacritic as it crashes) into one general rule.

Two concrete failures from the issue:
- `quarter` `/ˈkoː.tɘ/` — bare `o` had no mapping (the length mark `ː` is stripped, leaving an unmapped `o`).
- `area` `/ˈɛə̯ɹɪə̯/` — the non-syllabic diacritic `̯` (U+032F) was unhandled. (The issue comment pointed at the tie bar `͡` U+0361, but that was already ignored; the real culprit was the look-alike U+032F.)

## How

Instead of enumerating diacritics one crash at a time, handle the whole class:
- **NFD-normalize input** so precomposed accents (`ĩ`, `ñ`, `é`) decompose into a base we can map plus a combining mark we can drop.
- **Drop unrecognized combining marks (`\p{M}`) and modifier letters (`\p{Lm}`) in the tokenizer** instead of throwing — one rule covering ~2,500 codepoints. Genuine garbage (emoji, `@`, an unmapped base letter) still errors.
- **Keep tie bars pre-stripped** (`ignoredSymbols` is now spacing + `U+0361`/`U+035C`) so affricates like `d͡ʒ` still collapse into one chunk.
- **NFD-normalize the match keys** so `ç` works whether it arrives composed or decomposed (the only chunk affected).
- **Add the `o`/`oː` → `aw` vowel mapping** — a base-letter gap normalization can't fill. Picked `aw` to mirror the existing precedent where close-mid front `e` is respelled like `ɛ`, not like the diphthong `eɪ`.

## Boundary

Modifier *symbols* (`\p{Sk}` — IPA tone letters and a standalone rhotic hook) are intentionally **not** auto-dropped, since that Unicode category also holds typographic characters (`^`, `` ` ``, `´`) better left as errors. None appear in English dictionary IPA, and rhotic vowels arrive precomposed as `ɚ`/`ɝ` (already mapped).

## Verification

- 45/45 unit tests pass (6 new: aspiration, NFD-decomposed accent, half-length, voiceless ring, plus `ç` and nasal-vowel regression guards).
- ESLint and `tsc --noEmit` clean.
- Broad manual battery: aspiration / labialization / palatalization / dental / raised / breathy / creaky all degrade gracefully; `blã`→`blah`, `ɪç`→`(i|ih)ch`; both issue words convert; emoji / `@` / `ɲ` still error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
